### PR TITLE
Relocate logic in wrong spot

### DIFF
--- a/handlers/Main.cfc
+++ b/handlers/Main.cfc
@@ -1,4 +1,4 @@
-﻿relocate( "main.index" );
+component {
 
 	// Default Action
 	function index(event,rc,prc){
@@ -8,7 +8,7 @@
 
 	// Do something
 	function doSomething(event,rc,prc){
-		setNextEvent("main.index");
+		relocate( "main.index" );
 	}
 
 	/************************************** IMPLICIT ACTIONS *********************************************/


### PR DESCRIPTION
Looks like adding the relocate logic was somehow where the 
`component { ` declaration was supposed to be. Moved relocate to the `doSomething()`